### PR TITLE
Add mobile-friendly popups

### DIFF
--- a/Extension/styles/mainStyle.css
+++ b/Extension/styles/mainStyle.css
@@ -448,19 +448,36 @@
 }
 
 .mcsPopup {
-    position: absolute;
-    top: 0;
-    left: 100%;
     background-color: #ececec;
     color: #575757;
     border-color: #6c757d;
     border-style: solid;
     border-width: thick;
     border-radius: 0.5rem;
-    width: 614px;
     padding: 0 0.5rem 0.5rem 0.5rem;
     z-index: 999;
     cursor: default;
+}
+
+@media (min-width: 983px) {
+    .mcsPopup {
+        position: absolute;
+        top: 0;
+        left: 100%;
+        width: 614px;
+    }
+}
+
+/* Prevent popups from rendering off-screen on mobile */
+@media (max-width: 982px) {
+    .mcsPopup {
+        position: fixed;
+        top: 10%;
+        left: 10%;
+        max-width: 80%;
+        height: 80%;
+        overflow-y: scroll;
+    }
 }
 
 .tooltip-icon {


### PR DESCRIPTION
Quick CSS-only fix for being unable to select equipment on mobile. As it is, popups have a fixed width and are anchored to the right side of the triggering element. This leads to the popups (especially equipment) mostly clipping off the right side of the screen.

This change renders popups differently for narrow viewports. Instead of the popup being anchored with an absolute position, it's rendered kind of like a smaller modal. It fills the center of the viewport with enough space on all sides to click out of it without dismissing Combat Simulator altogether.

(a more robust fix would make it an _actual_ modal with a button to dismiss, but ain't nobody got time for that)

![image](https://user-images.githubusercontent.com/13140617/235374557-a69fc602-3329-41b6-9e6f-80815e06e54f.png)

